### PR TITLE
make answers more strict

### DIFF
--- a/app/helpers/question_helper.rb
+++ b/app/helpers/question_helper.rb
@@ -8,7 +8,7 @@ module RubyConans
         begin
           proc {
             $SAFE=4
-            eval(question) == eval(answer)
+            eval(question).inspect == answer.tr("'",'"').tr(' ','').gsub(',]',']')
           }.call 
         rescue SecurityError 
           #puts 'ah ah ah, you didn't say the magic word'


### PR DESCRIPTION
This would make it so that answers had to match the actual output of the question in primitives. This means you can't plug in the question as the answer and have it pass. 

DISCLAIMER: this is untested, merge at your own risk.
